### PR TITLE
Copie des fichiers vidéos

### DIFF
--- a/config/assets.js
+++ b/config/assets.js
@@ -7,7 +7,10 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.ignores.add("src/!(assets)/**/node_modules");
 
   // images 
-  eleventyConfig.addPassthroughCopy("src/**/!(node_modules)/**/*.{jpg,png,ico,pdf,svg}");
+  eleventyConfig.addPassthroughCopy("src/**/!(node_modules)/**/*.{jpg,png,ico,pdf,svg,gif}");
+
+  // videos
+  eleventyConfig.addPassthroughCopy("src/**/!(node_modules)/**/*.{webm,mov,mp4}");
   
   // data
   eleventyConfig.addPassthroughCopy("src/**/!(node_modules)/**/*.{txt,edi,csv,json,pdf}");

--- a/config/assets.js
+++ b/config/assets.js
@@ -10,7 +10,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/**/!(node_modules)/**/*.{jpg,png,ico,pdf,svg,gif}");
 
   // videos
-  eleventyConfig.addPassthroughCopy("src/**/!(node_modules)/**/*.{webm,mov,mp4}");
+  eleventyConfig.addPassthroughCopy("src/**/!(node_modules)/**/*.{webm,mov,mp4,ogv}");
   
   // data
   eleventyConfig.addPassthroughCopy("src/**/!(node_modules)/**/*.{txt,edi,csv,json,pdf}");


### PR DESCRIPTION
Actuellement, les fichiers avec les extensions .mp4, .webm, .mov, .ogv et .gif ne sont pas copiés dans le répertoire du site à la compilation, et ne sont donc pas accessibles, par exemple pour intégrer une vidéo dans nos pages.
Bien entendu, il suffirait de modifier l'extension pour que le fichier soit copié quand même, donc cette pull request permet uniquement de garder l'extension originale, afin de ne pas prêter à confusion en insérant des vidéos avec une extension en .json, par exemple.